### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/benm0131/f4b956b1-8f22-4bd9-aaec-d4ce1107cea0/c6b60dd7-06ef-49bb-b6ce-c82ea4a45f46/_apis/work/boardbadge/abc561fe-2881-479a-ab97-707aba4ee935)](https://dev.azure.com/benm0131/f4b956b1-8f22-4bd9-aaec-d4ce1107cea0/_boards/board/t/c6b60dd7-06ef-49bb-b6ce-c82ea4a45f46/Microsoft.RequirementCategory)
 # Calculator.js: a node.js Demonstration Project
 
 An example node.js project, including tests with mocha, that behaves like


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#26](https://dev.azure.com/benm0131/f4b956b1-8f22-4bd9-aaec-d4ce1107cea0/_workitems/edit/26). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.